### PR TITLE
setup mkdocs with material for mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,36 @@
 site_name: CC Docs
 site_description: Crystal Clear Documentation 
+
+theme:
+    name: material
+    logo: images/Credits/image1.png
+    favicon: images/Credits/image1.png
+    features:
+        - navigation.top
+  
+    palette:
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: cyan
+      accent: light green
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: cyan
+      accent: light green 
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+plugins:
+    - search
+
 nav:
     - Home: 'index.md'
     - FAQ: 'FAQ.md'


### PR DESCRIPTION
Use the popular mkdocs theme [material for mkdocs](https://squidfunk.github.io/mkdocs-material/getting-started/) for documentation

This is a simple edit of the mkdocs.yml file to bring the theme to the current docs

The theme is installed via pip similarly to [mkdocs](https://www.mkdocs.org/):
`pip install mkdocs-material`

Features:
- Advanced Search
- Dark/Light Modes
- Color and navigation customization
- Much more!

Not Included but happy to support:
The sites documentation/website can easily be hosted on github for free using the gh-pages branch. If you would like I can setup this up/make a pull request for this! That way updating the site is easy 

Let me know if I can make any edits with this or if you have specific help/needs with the docs. I am decently well-versed in mkdocs and the material theme. Happy to help pitch in on an awesome project! Thanks for your amazing work! :)

Below are some screen shots of what the theme looks like with the current docs:
![crystalClear1](https://user-images.githubusercontent.com/28318597/176069878-ffe7c398-eb9a-4c7a-a799-bc0e45799206.png)
![crystalClear2](https://user-images.githubusercontent.com/28318597/176069881-df632d2d-0eea-475b-a02b-b44a755d7a96.png)
![crystalClear3](https://user-images.githubusercontent.com/28318597/176069887-4deec7fa-0138-44b5-a473-93dc2eba86b6.png)
![crystalClear4](https://user-images.githubusercontent.com/28318597/176069893-09e74b17-1470-4f54-b162-0515bcbbe818.png)

